### PR TITLE
Explodes on functions with overwritten `toString`

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,11 @@ var Wrapper = exports.Wrapper = function Wrapper(fn, context) {
 	this.fn = fn;
 	
 	// Detect the dependencies using the regex
-	this.deps = fn.toString().match(FN_ARGS)[1].split(',').map(function(i) { return i.trim(); }).filter(function(i) { return i; });
+	this.deps = Function.toString.call(fn)
+		.match(FN_ARGS)[1]
+		.split(',')
+		.map(function(i) { return i.trim(); })
+		.filter(function(i) { return i; });
 	
 	// Create a map of dependency names for easy presence detection
 	this.requires = {};

--- a/tests.js
+++ b/tests.js
@@ -1,3 +1,6 @@
+/* global describe, it */
+/* jshint unused:false */
+
 var demand = require('must'),
 	di = require('./index');
 
@@ -8,6 +11,10 @@ var fn_async = function(callback) { setTimeout(callback, 500, null, true) };
 var fn_one = function(one) { return true; };
 var fn_scope = function(){ return this; };
 var fn_error = function() { throw thrownErr };
+var fn_overwritten_toString = function(){ return true};
+fn_overwritten_toString.toString = function(){
+	return "toString overwritten";
+};
 var scope = {};
 var notAFunction = {};
 
@@ -27,6 +34,13 @@ describe('AsyncDI', function() {
 			demand(function(){
 				di(notAFunction);
 			}).to.throw(/function/i);
+		});
+	});
+	describe('(fn_overwritten_toString)', function(){
+		it("should not throw an error", function(){
+			demand(function(){
+				di(fn_overwritten_toString);
+			}).to.not.throw();
 		});
 	});
 	describe('fn_basic.isAsync', function() {

--- a/tests.js
+++ b/tests.js
@@ -7,7 +7,7 @@ var demand = require('must'),
 var thrownErr = new Error("Should've been caught by asyncdi");
 
 var fn_basic = function() { return true; };
-var fn_async = function(callback) { setTimeout(callback, 500, null, true) };
+var fn_async = function(callback) { setTimeout(callback, 0, null, true) };
 var fn_one = function(one) { return true; };
 var fn_scope = function(){ return this; };
 var fn_error = function() { throw thrownErr };

--- a/tests.js
+++ b/tests.js
@@ -29,15 +29,15 @@ describe('AsyncDI', function() {
 			di(fn_basic).must.be.an.instanceof(di.Wrapper);
 		});
 	});
-	describe('(notAFunction)', function(){
-		it('must throw an error', function(){
+	describe('(notAFunction)', function() {
+		it('must throw an error', function() {
 			demand(function(){
 				di(notAFunction);
 			}).to.throw(/function/i);
 		});
 	});
-	describe('(fn_overwritten_toString)', function(){
-		it("should not throw an error", function(){
+	describe('(fn_overwritten_toString)', function() {
+		it("should not throw an error", function() {
 			demand(function(){
 				di(fn_overwritten_toString);
 			}).to.not.throw();
@@ -91,15 +91,15 @@ describe('AsyncDI', function() {
 			demand(di(fn_one).requires.two).be.undefined();
 		});
 	});
-	describe('(fn_scope).call(scope, callback)', function(){
-		it('must return scope', function(done){
-			di(fn_scope).call(scope, function(err, val){
+	describe('(fn_scope).call(scope, callback)', function() {
+		it('must return scope', function(done) {
+			di(fn_scope).call(scope, function(err, val ){
 				demand(val).equal(scope);
 				done();
 			});
 		});
 	});
-	describe('(fn_scope, scope).call(callback)', function(){
+	describe('(fn_scope, scope).call(callback)', function() {
 		it('must return scope', function(done){
 			di(fn_scope, scope).call(function(err, val){
 				demand(val).equal(scope);
@@ -107,8 +107,8 @@ describe('AsyncDI', function() {
 			});
 		});
 	});
-	describe('(fn_error).call(callback)', function(){
-		it('must return thrownErr', function(done){
+	describe('(fn_error).call(callback)', function() {
+		it('must return thrownErr', function(done) {
 			di(fn_error).call(function(err, val){
 				demand(err).equal(thrownErr);
 				done();


### PR DESCRIPTION
E.g.

``` js
var f = function (){};
di(f); //KABOOM!
```

PR with fix coming.
